### PR TITLE
helpコマンドの結果をIMで取得するように変更

### DIFF
--- a/yig/plugins/help.py
+++ b/yig/plugins/help.py
@@ -1,7 +1,7 @@
 import botocore
 
 from yig.bot import listener
-from yig.util import get_user_param, get_state_data, get_pc_icon_url
+from yig.util import get_user_param, get_state_data, get_pc_icon_url, get_now_status
 
 import yig.config
 import json
@@ -52,15 +52,18 @@ def help(bot):
     if user_param is not None:
         block_content.append(divider_builder())
         pc_name = user_param['name']
-        now_hp = user_param['HP']
-        now_mp = user_param['MP']
-        now_san = user_param['現在SAN']
+        max_hp = user_param['HP']
+        now_hp = get_now_status('HP', user_param, state_data)
+        max_mp = user_param['MP']
+        now_mp = get_now_status('MP', user_param, state_data)
+        max_san = user_param['現在SAN']
+        now_san = get_now_status('SAN', user_param, state_data, '現在SAN')
         db = user_param['DB']
         user_content = {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*PC INFO*\n\n*Name:* {pc_name}\n*HP:*  {now_hp}/{now_hp}  *MP:* {now_mp}/{now_mp}  *SAN:* {now_san}/{now_san}  *DB:*  {db}"
+                "text": f"*PC INFO*\n\n*Name:* {pc_name}\n*HP:*  {now_hp}/{max_hp}  *MP:* {now_mp}/{max_mp}  *SAN:* {now_san}/{max_san}  *DB:*  {db}"
             },
             "accessory": {
                 "type": "image",

--- a/yig/plugins/help.py
+++ b/yig/plugins/help.py
@@ -9,12 +9,25 @@ import json
 
 @listener("HELP")
 def help(bot):
-    """:question: *help message*`/cc help`"""
+    """:question: *help message*\n`/cc help`"""
+    channel = bot.user_id
+    help_content = help_content_builder(bot.team_id, bot.user_id, bot.get_listener())
+    return list(map(lambda c: dict(c, channel=channel), help_content)), None
+
+
+@listener("OPENHELP")
+def open_help(bot):
+    """:school: *open help message*\n`/cc openhelp`"""
+    help_content = help_content_builder(bot.team_id, bot.user_id, bot.get_listener())
+    return help_content, None
+
+
+def help_content_builder(team_id, user_id, listener):
     about = "This is the command to play Call of Cthulhu.\nEnjoy!"
     refer = "*<https://github.com/cahlchang/CoCNonKP/blob/master/command_reference.md|All Documents.>*\n\n"
 
     dict_function = {}
-    for list_function in bot.get_listener().values():
+    for list_function in listener.values():
         for datum in list_function:
             if datum["function"].__name__ == "roll_skill" or datum["function"].__name__.startswith("easteregg"):
                 continue
@@ -22,8 +35,8 @@ def help(bot):
 
     user_param = None
     try:
-        state_data = get_state_data(bot.team_id, bot.user_id)
-        user_param = get_user_param(bot.team_id, bot.user_id, state_data["pc_id"])
+        state_data = get_state_data(team_id, user_id)
+        user_param = get_user_param(team_id, user_id, state_data["pc_id"])
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == 'NoSuchKey':
             print('new_participant')
@@ -67,7 +80,7 @@ def help(bot):
             },
             "accessory": {
                 "type": "image",
-                "image_url": get_pc_icon_url(bot.team_id, bot.user_id, state_data["pc_id"]),
+                "image_url": get_pc_icon_url(team_id, user_id, state_data["pc_id"]),
                 "alt_text": "image"
             }
         }
@@ -110,7 +123,7 @@ def help(bot):
     if user_param is not None:
         help_content.extend(user_roll_help_content(skill_list, user_param, state_data))
 
-    return help_content, None
+    return help_content
 
 
 def user_roll_help_content(skill_list, user_param, state_data):

--- a/yig/plugins/help.py
+++ b/yig/plugins/help.py
@@ -123,7 +123,6 @@ def user_roll_help_content(skill_list, user_param, state_data):
             skill_name = content[0]
             skill_targ = content[1]
             lst_message.append(f"*{skill_name}* (target point *{skill_targ}*)\n`/cc {skill_name} [+|-|*|/][number]`")
-            print(i, len(lst_content))
             if i > 0 and i % 9 == 0 or len(lst_content) == i + 1:
                 lst.append(section_builder(lst_message))
                 lst_message = []

--- a/yig/util.py
+++ b/yig/util.py
@@ -166,6 +166,14 @@ def get_charaimage(team_id, user_id, pc_id):
     return image
 
 
+def get_now_status(status_name, user_param, state_data, status_name_alias=None):
+    current_status = user_param[status_name] if status_name_alias is None else user_param[status_name_alias]
+
+    if status_name in state_data:
+        current_status = int(current_status) + int(state_data[status_name])
+    return current_status
+
+
 # todo いい感じにする
 def get_status_message(message_command, dict_param, dict_state):
     name = dict_param['name']

--- a/yig/util.py
+++ b/yig/util.py
@@ -67,13 +67,11 @@ def post_result(token,
                 user_id,
                 channel_id,
                 return_content,
-                color,
-                response_type="in_channel"):
+                color):
     command_url = "https://slack.com/api/chat.postMessage?"
     payload = {
         "token": token,
-        "channel": channel_id,
-        "response_type": response_type,
+        "channel": channel_id
     }
     def request(command_url, payload):
         print(payload)


### PR DESCRIPTION
### 概要

https://github.com/cahlchang/CoCBotKP/issues/87

情報量が多く、helpコマンドでログが流れてしまうためIMから情報を飛ばすように変更。
また、チャンネルに貼り付ける機能として`openhelp` 機能を追加。
（新規の人に説明する用途として）

### 議論ポイント

現在の仕様だと `/cc help` コマンドを打った結果は表示されます。
ログ量という点では問題は無いと思うのですが、それがノイズに感じる人がいるかもしれません。
消す事も可能ですが、コマンドを打ったかどうかを確認する意図があってもいいかなと思って一旦残しています。
人によって感じ方は違いそうな場所な気がするので、違和感が出たら消す方向にします。